### PR TITLE
Redirect for cms signin page to LMS login page

### DIFF
--- a/cms/djangoapps/contentstore/views/public.py
+++ b/cms/djangoapps/contentstore/views/public.py
@@ -42,6 +42,11 @@ def login_page(request):
     """
     Display the login form.
     """
+    # Redirect user to LMS login page if `DISABLE_STUDIO_SSO_OVER_LMS` feature
+    # flag is not enabled and user tries to access the signin page using URL.
+    if not settings.FEATURES.get('DISABLE_STUDIO_SSO_OVER_LMS', False):
+        return redirect_with_get(settings.FRONTEND_LOGIN_URL, request.GET, False)
+
     csrf_token = csrf(request)['csrf_token']
     if request.user.is_authenticated:
         return redirect('/course/')


### PR DESCRIPTION
**Description:** 
If `DISABLE_STUDIO_SSO_OVER_LMS` feature flag is not set to `True`, redirect the user to lms login page when user tries to access the CMS signin page  using the URL

**JIRA:** 
https://edlyio.atlassian.net/browse/EDE-765

**Merge checklist:**

- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated

**Post merge:**
- [ ] Delete working branch (if not needed anymore)


**Note:** Please add screenshots for any viewable change.
