### PR TITLE
[POC][Do not merge] Add code for multisite admin panel POC

### DIFF
--- a/lms/urls.py
+++ b/lms/urls.py
@@ -1051,3 +1051,16 @@ urlpatterns += [
 ]
 
 urlpatterns.extend(plugin_urls.get_patterns(plugin_constants.ProjectType.LMS))
+
+if settings.ADD_EDLY_URLS:
+    urlpatterns += [
+        url(r'^api/edly_panel/', include('edly_panel_app.api.urls', namespace='edly_panel_api')),
+    ]
+
+
+if settings.FEATURES.get('ENABLE_MULTI_SITE_ADMIN_PANEL'):
+    from importlib import import_module
+    module_path, method = '.'.join(settings.ADMIN_SITES_SETTER.split('.')[:-1]), settings.ADMIN_SITES_SETTER.split('.')[-1]
+    admin_sites_setter = getattr(import_module(module_path), method)
+    # admin_sites_setter = import_module(settings.ADMIN_SITES_SETTER)
+    admin_sites_setter(urlpatterns)

--- a/openedx/features/redhouse_features/admin.py
+++ b/openedx/features/redhouse_features/admin.py
@@ -1,0 +1,72 @@
+"""
+Register redhouse multi-site admin panels
+"""
+from django.contrib.admin import AdminSite
+from django.contrib import admin
+from django.db.models import Q
+
+from django.contrib.auth.models import Permission
+
+from django.contrib.auth import get_user_model
+
+from openedx.features.edly.models import EdlyUserProfile, EdlySubOrganization
+
+
+User = get_user_model()
+
+
+class RedhouseAdminSite(AdminSite):
+    site_header = "Redhouse site 1"
+    site_title = "Redhouse site 1"
+    index_title = "Welcome to Redhouse site 1"
+
+redhouse_1_admin_site = RedhouseAdminSite(name='redhouse_1_admin')
+
+# Assign the permissions according to the requirements
+# e,g, assign user permission to a staff user (non super user) to enable them to
+# view users table on `redhouse-admin` site
+
+
+class SiteQuerysetMixin(admin.ModelAdmin):
+
+    def get_queryset(self, request):
+        qs = super(SiteQuerysetMixin, self).get_queryset(request)
+
+        if request.user.is_superuser:
+            return qs
+
+        request_site = request.site
+        queries = Q()
+
+        for site_filter in self.site_filters:
+            queries |= Q(**{
+                site_filter: request_site
+            })
+
+        return qs.filter(queries)
+
+
+class UserAdmin(SiteQuerysetMixin):
+    site_filters = (
+        'edly_profile__edly_sub_organizations__lms_site',
+        'edly_profile__edly_sub_organizations__studio_site'
+    )
+
+
+class EdlyUserProfileAdmin(SiteQuerysetMixin):
+    site_filters = (
+        'edly_sub_organizations__lms_site',
+        'edly_sub_organizations__studio_site'
+    )
+
+
+class EdlySubOrganizationAdmin(SiteQuerysetMixin):
+    site_filters = (
+        'lms_site',
+        'studio_site'
+    )
+
+
+redhouse_1_admin_site.register(EdlyUserProfile, EdlyUserProfileAdmin)
+redhouse_1_admin_site.register(User, UserAdmin)
+redhouse_1_admin_site.register(EdlySubOrganization, EdlySubOrganizationAdmin)

--- a/openedx/features/redhouse_features/admin_utils.py
+++ b/openedx/features/redhouse_features/admin_utils.py
@@ -1,0 +1,14 @@
+
+from six import iteritems
+from django.conf.urls import include, url
+
+from .admin import redhouse_1_admin_site
+
+SITES = {
+    'redhouse': redhouse_1_admin_site
+}
+
+
+def add_admin_sites(urlpatters):
+    for site, admin in iteritems(SITES):
+        urlpatters += url(r'{}-admin'.format(site), include(admin.urls)),


### PR DESCRIPTION
### Description
Contains code for POC about how we can have different admin panels for different sites.

Requires the following settings:
```
## for multi admin sites POC:
FEATURES['ENABLE_MULTI_SITE_ADMIN_PANEL'] = True

# from openedx.features.redhouse_features.admin_utils import add_admin_sites
ADMIN_SITES_SETTER = 'openedx.features.redhouse_features.admin_utils.add_admin_sites'
```