### PR TITLE
Add email based contact us form

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -3536,3 +3536,7 @@ USER_STATE_BATCH_SIZE = 5000
 from openedx.core.djangoapps.plugins import plugin_apps, plugin_settings, constants as plugin_constants
 INSTALLED_APPS.extend(plugin_apps.get_apps(plugin_constants.ProjectType.LMS))
 plugin_settings.add_plugins(__name__, plugin_constants.ProjectType.LMS, plugin_constants.SettingsType.COMMON)
+
+################### Redhouse features ##########################
+
+SUPPORT_DESK_EMAILS = []

--- a/lms/envs/production.py
+++ b/lms/envs/production.py
@@ -1128,3 +1128,7 @@ plugin_settings.add_plugins(__name__, plugin_constants.ProjectType.LMS, plugin_c
 ########################## Derive Any Derived Settings  #######################
 
 derive_settings(__name__)
+
+############################ Redhouse Features #####################################
+
+SUPPORT_DESK_EMAILS = ENV_TOKENS.get('SUPPORT_DESK_EMAILS', SUPPORT_DESK_EMAILS)

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -1048,6 +1048,7 @@ if settings.FEATURES.get('ENABLE_API_DOCS'):
 # edx-drf-extensions csrf app
 urlpatterns += [
     url(r'', include('csrf.urls')),
+    url(r'', include('openedx.features.redhouse_features.urls'))
 ]
 
 urlpatterns.extend(plugin_urls.get_patterns(plugin_constants.ProjectType.LMS))

--- a/openedx/features/redhouse_features/emails.py
+++ b/openedx/features/redhouse_features/emails.py
@@ -1,0 +1,7 @@
+from openedx.core.djangoapps.ace_common.message import BaseMessageType
+
+
+class SupportEmail(BaseMessageType):
+    """
+    Email sent to support when there is a "Contact us" form submission.
+    """

--- a/openedx/features/redhouse_features/urls.py
+++ b/openedx/features/redhouse_features/urls.py
@@ -1,0 +1,13 @@
+"""
+URLs for the student support app.
+"""
+from django.conf.urls import url
+
+from openedx.features.redhouse_features.views import email_support
+
+
+app_name = 'redhouse_features'
+
+urlpatterns = [
+    url(r'^contact/$', email_support, name='email_support'),
+]

--- a/openedx/features/redhouse_features/utils.py
+++ b/openedx/features/redhouse_features/utils.py
@@ -1,0 +1,73 @@
+import logging
+
+from django.conf import settings
+
+from edx_ace import ace
+from edx_ace.recipient import Recipient
+from openedx.core.djangoapps.ace_common.template_context import get_base_template_context
+from openedx.core.djangoapps.theming.helpers import get_current_site
+
+from openedx.features.redhouse_features.emails import SupportEmail
+
+
+log = logging.getLogger(__name__)
+
+EMAIL_CLASSES = {
+    'support': SupportEmail
+}
+
+
+def send_notification_email_to_support(subject, body, name, email, additional_info=None, course=None):
+    """
+    Sending a notification-email to the Support Team.
+
+    Arguments:
+        subject         - Email subject
+        body            - Email body
+        name            - username of the requester user
+        email           - email of the requester user
+        additional_info - Any additional fields for email body
+        course          - Name of the course (filled from the form)
+    """
+    key = 'support'
+    dest_emails = settings.SUPPORT_DESK_EMAILS
+    data = {
+        'name': name,
+        'email': email,
+        'body': body,
+        'course': course,
+        'additional_info': additional_info,
+    }
+    send_notification(key, data, subject, dest_emails)
+
+
+def send_notification(key, data, subject=None, dest_emails=[]):
+    """
+    Send an email notification to provided email addresses.
+
+    Arguments:
+        key         - Email template will be selected on the basis of key
+        data        - Dict containing context/data for the template
+        subject     - Email subject
+        dest_emails - List of destination emails
+
+    """
+    site = get_current_site()
+    message_context = get_base_template_context(site)
+
+    message_context.update(data)
+
+    if subject:
+        message_context['subject'] = subject
+
+    for email in dest_emails:
+        log.info('Sending support email with subject "{}" to {}'.format(
+            subject, email
+        ))
+
+        msg = EMAIL_CLASSES[key]().personalize(
+            recipient=Recipient(username='', email_address=email),
+            language=settings.LANGUAGE_CODE,
+            user_context=message_context,
+        )
+        ace.send(msg)

--- a/openedx/features/redhouse_features/views.py
+++ b/openedx/features/redhouse_features/views.py
@@ -1,0 +1,31 @@
+import json
+from logging import getLogger
+
+from django.views.decorators.http import require_http_methods
+from django.http import HttpResponse
+from rest_framework import status
+
+from openedx.features.redhouse_features.utils import send_notification_email_to_support
+
+
+logger = getLogger(__name__)
+
+
+@require_http_methods(["POST"])
+def email_support(request):
+    body = json.loads(request.body)
+
+    try:
+        send_notification_email_to_support(
+            subject=body['subject'],
+            body=body['comment']['body'],
+            name=body['requester']['name'],
+            email=body['requester']['email'],
+            course=body['custom_fields'][0]['value']
+        )
+
+        return HttpResponse(status=status.HTTP_201_CREATED)
+
+    except Exception:
+        logger.error('Error occurred while trying to send contact-support email.', exc_info=True)
+        return HttpResponse(status=status.HTTP_500_INTERNAL_SERVER_ERROR)


### PR DESCRIPTION
**JIRA:** 
https://edlyio.atlassian.net/browse/EDE-832


**Description:** 
Replace the default "Contact us"  view (zendesk) with "Email" based support.

**Required configurations**:
We need to set emails as list in config var `SUPPORT_DESK_EMAILS`. All support submissions will be sent to these emails.