### PR TITLE
Make Event page work for SULC 

### DIFF
--- a/common/djangoapps/edxmako/shortcuts.py
+++ b/common/djangoapps/edxmako/shortcuts.py
@@ -38,7 +38,9 @@ def marketing_link(name):
     """
     # link_map maps URLs from the marketing site to the old equivalent on
     # the Django site
-    link_map = settings.MKTG_URL_LINK_MAP
+    # pick up the MKTG_URL_LINK_MAP from site configurations for the REDHOUSE specific redirection
+    link_map = configuration_helpers.get_value('MKTG_URL_LINK_MAP', settings.MKTG_URL_LINK_MAP)
+
     enable_mktg_site = configuration_helpers.get_value(
         'ENABLE_MKTG_SITE',
         settings.FEATURES.get('ENABLE_MKTG_SITE', False)

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -288,6 +288,7 @@ urlpatterns += [
     # TODO: These views need to be updated before they work
     url(r'^calculate$', util_views.calculate),
 
+    url(r'^events/?$', branding_views.courses, name='events'),
     url(r'^courses/?$', branding_views.courses, name='courses'),
 
     #About the course


### PR DESCRIPTION
**Description:** 
Needed to redirect the SULC `/courses` HTML view to the `/events` didn't set 404 on courses but now is accessible on both links

How to make it work?
In admin panel add 
` "MKTG_URL_LINK_MAP":{
    "COURSES":"events"
  }`
in site configuration of the site you want to make event URL work. by this the navbar will automatically fetch `events` URL rather than courses.

**JIRA:** 
https://edlyio.atlassian.net/browse/EDE-865

**Testing instructions:**
check if `/events` page work on SULC

**Merge checklist:**

- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated

**Post merge:**
- [ ] Delete working branch (if not needed anymore)

