### PR TITLE
[EDE-839] Turn on advance xblock's in all of the courses by default

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -1416,6 +1416,54 @@ ADVANCED_PROBLEM_TYPES = [
     {
         'component': 'drag-and-drop-v2',
         'boilerplate_name': None
+    },
+    {
+        'component': 'done',
+        'boilerplate_name': None
+    },
+    {
+        'component': 'google-document',
+        'boilerplate_name': None
+    },
+    {
+        'component': 'google-calendar',
+        'boilerplate_name': None
+    },
+    {
+        'component': 'lti_consumer',
+        'boilerplate_name': None
+    },
+    {
+        'component': 'poll',
+        'boilerplate_name': None
+    },
+    {
+        'component': 'survey',
+        'boilerplate_name': None
+    },
+    {
+        'component': 'vectordraw',
+        'boilerplate_name': None
+    },
+    {
+        'component': 'freetextresponse',
+        'boilerplate_name': None
+    },
+    {
+        'component': 'edx_sga',
+        'boilerplate_name': None
+    },
+    {
+        'component': 'xblock-pdf',
+        'boilerplate_name': None
+    },
+    {
+        'component': 'problem-builder',
+        'boilerplate_name': None
+    },
+    {
+        'component': 'video_xblock',
+        'boilerplate_name': None
     }
 ]
 
@@ -1617,6 +1665,7 @@ COMPLETION_VIDEO_COMPLETE_PERCENTAGE = 0.95
 
 from openedx.core.djangoapps.plugins import plugin_apps, plugin_settings, constants as plugin_constants
 INSTALLED_APPS.extend(plugin_apps.get_apps(plugin_constants.ProjectType.CMS))
+INSTALLED_APPS += ['freetextresponse']
 plugin_settings.add_plugins(__name__, plugin_constants.ProjectType.CMS, plugin_constants.SettingsType.COMMON)
 
 # Course exports streamed in blocks of this size. 8192 or 8kb is the default

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -41,7 +41,7 @@ git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.1.6#egg=xblock-d
 -e git+https://github.com/edx-solutions/xblock-google-drive.git@138e6fa0bf3a2013e904a085b9fed77dab7f3f21#egg=xblock-google-drive
 git+https://github.com/open-craft/xblock-poll@add89e14558c30f3c8dc7431e5cd6536fff6d941#egg=xblock-poll==1.5.1
 -e git+https://github.com/raccoongang/xblock-pdf.git@sgab-v.1.0.1#egg=xblock-pdf
--e git+https://github.com/edly-io/xblock-video.git@dev#egg=video_xblock
+-e git+https://github.com/edx/xblock-free-text-response.git#egg=xblock-free-text-response
 -e common/lib/xmodule
 amqp==1.4.9               # via kombu
 analytics-python==1.2.9

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -45,7 +45,6 @@ git+https://github.com/open-craft/xblock-poll@add89e14558c30f3c8dc7431e5cd6536ff
 git+ssh://git@github.com/edly-io/edly-panel-edx-app.git@edly-1.1.1#egg=edly-panel-app==edly-1.1.1
 git+ssh://git@github.com/edly-io/figures.git@edly-1.0.0#egg=figures==edly-1.0.0
 -e git+https://github.com/raccoongang/edx_xblock_scorm.git@v1.0.3#egg=edx_xblock_scorm==v1.0.3
--e git+https://github.com/edly-io/xblock-video.git@dev#egg=video_xblock
 -e common/lib/xmodule
 alabaster==0.7.12         # via sphinx
 amqp==1.4.9


### PR DESCRIPTION
### [EDE-839] Turn on advance xblock's in all of the courses by default
**Description:** 

**JIRA:** 
https://edlyio.atlassian.net/browse/EDE-839****

The following xblocks should appear on all courses by default under the advanced tab.

<img width="622" alt="advanced" src="https://user-images.githubusercontent.com/36886070/92468745-17610980-f1ed-11ea-987b-733ef9b6bd2d.png">
