### PR TITLE
[SULC] Blocking the URLS '/courses'

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1303,6 +1303,9 @@ MIDDLEWARE_CLASSES = [
     'django_comment_client.utils.ViewNameMiddleware',
     'codejail.django_integration.ConfigureCodeJailMiddleware',
 
+    # middleware to block certain url names
+    'openedx.features.redhouse_features.middleware.BlockingUrlMiddleware',
+
     # catches any uncaught RateLimitExceptions and returns a 403 instead of a 500
     'ratelimitbackend.middleware.RateLimitMiddleware',
 

--- a/openedx/features/redhouse_features/middleware.py
+++ b/openedx/features/redhouse_features/middleware.py
@@ -1,0 +1,24 @@
+"""
+Middleware for the redhouse app
+"""
+
+from django.http import Http404
+from django.urls import resolve
+
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
+
+
+class BlockingUrlMiddleware(object):
+    """
+    Django middleware object to return 404 on certain url names
+    """
+
+    def process_view(self, request, view_func, view_args, view_kwargs):
+        """
+        runs before any view and will block the url name mentioned in BLOCKED_URL_NAMES
+        as a list in site configurations
+        """
+
+        blocked_url_names = configuration_helpers.get_value('BLOCKED_URL_NAMES')
+        if blocked_url_names and resolve(request.path).url_name in blocked_url_names:
+            raise Http404


### PR DESCRIPTION
**Description:** 
In SULC we were supposed to replace the '/courses' URL with '/events', we already had created another URL for events and hence courses was already present, we had block that and for this we can add `BLOCKED_URL_NAMES` in site configurations to block certain URLs and return 404

**JIRA:** 
https://edlyio.atlassian.net/browse/EDE-901

**Testing instructions:**

1. on sulc domain '/events' should work and '/courses' should return 404
2. check if all other links and courses links are working and no abnormal behavior 
3. on other domain e:g Redhouse '/courses' should be working and '/events' should return 404 
4. heck if all other links and courses links are working and no abnormal behavior 

**Merge checklist:**

- [ ] All reviewers approved
- [ ] CI build is green
- [x] Documentation updated (not only docstrings)
- [x] Commits are (reasonably) squashed
- [x] Translations are updated

**Post merge:**
- [ ] Delete working branch (if not needed anymore)

