### PR TITLE
Add waffle switch for redhouse panel

### DIFF
--- a/openedx/features/redhouse_panel/views.py
+++ b/openedx/features/redhouse_panel/views.py
@@ -1,11 +1,19 @@
 """
 Sites admin dashboard views.
 """
+from django.contrib.auth.decorators import login_required
+from django.http import Http404
 from edxmako.shortcuts import render_to_response
 
+from openedx.features.redhouse_panel.waffle import waffle, ENABLE_REDHOUSE_PANEL
 
+
+@login_required
 def render_redhouse_panel(request):
     """
     View for admin panel dashboard.
     """
-    return render_to_response('redhouse_panel/redhouse_panel.html')
+    if waffle().is_enabled(ENABLE_REDHOUSE_PANEL) and request.user.is_staff:
+        return render_to_response('redhouse_panel/redhouse_panel.html')
+
+    raise Http404

--- a/openedx/features/redhouse_panel/waffle.py
+++ b/openedx/features/redhouse_panel/waffle.py
@@ -1,0 +1,17 @@
+"""
+Contains waffle switches related to redhouse panel.
+"""
+from openedx.core.djangoapps.waffle_utils import WaffleSwitchNamespace
+
+# Namespace
+WAFFLE_NAMESPACE = 'redhouse_panel'
+
+# Switches
+ENABLE_REDHOUSE_PANEL = 'enable_redhouse_panel'
+
+
+def waffle():
+    """
+    Returns the namespaced, cached, audited Waffle class for Redhouse Panel.
+    """
+    return WaffleSwitchNamespace(name=WAFFLE_NAMESPACE, log_prefix='Redhouse Panel: ')


### PR DESCRIPTION
**Description:** 
Add a waffle switch `redhouse_panel.enable_redhouse_panel` check to enable or disable the redhouse panel frontend.

**JIRA:** 
https://edlyio.atlassian.net/browse/EDE-976

**Merge checklist:**

- [ ] All reviewers approved
- [x] CI build is green
- [ ] Documentation updated (not only docstrings)
- [x] Commits are (reasonably) squashed
- [ ] Translations are updated

**Post merge:**
- [ ] Delete working branch (if not needed anymore)
