### PR TITLE
EDE-1006 Fixed redhouse 404 url resolver issue

### DIFF
--- a/openedx/features/redhouse_panel/urls.py
+++ b/openedx/features/redhouse_panel/urls.py
@@ -5,6 +5,7 @@ from django.conf.urls import url, include
 
 from openedx.features.redhouse_panel.views import render_redhouse_panel
 
+
 app_name = 'redhouse_panel'
 
 urlpatterns = [

--- a/openedx/features/redhouse_panel/urls.py
+++ b/openedx/features/redhouse_panel/urls.py
@@ -5,11 +5,9 @@ from django.conf.urls import url, include
 
 from openedx.features.redhouse_panel.views import render_redhouse_panel
 
-
 app_name = 'redhouse_panel'
 
 urlpatterns = [
+    url(r'^$', render_redhouse_panel, name='index'),
     url(r'api/v0/', include('openedx.features.redhouse_panel.api.v0.urls')),
-
-    url(r'', render_redhouse_panel, name='index'),
 ]


### PR DESCRIPTION
**Description:** EDE-1006 Fixed redhouse 404 url resolver issue

**JIRA:** 
https://edlyio.atlassian.net/browse/EDE-1006

**Testing instructions:**

https://dev.sulccontinuingeducation.org/redhouse-panel/api/v0/sit
The above link should give 404 page 

