### PR TITLE
uses simple query filter instead of regex filter

### DIFF
--- a/openedx/core/djangoapps/content/course_overviews/models.py
+++ b/openedx/core/djangoapps/content/course_overviews/models.py
@@ -7,6 +7,7 @@ from urlparse import urlparse, urlunparse
 
 from django.conf import settings
 from django.db import models, transaction
+from django.db.models import Q
 from django.db.models.fields import BooleanField, DateTimeField, DecimalField, TextField, FloatField, IntegerField
 from django.db.utils import IntegrityError
 from django.template import defaultfilters
@@ -576,7 +577,10 @@ class CourseOverview(TimeStampedModel):
             # In rare cases, courses belonging to the same org may be accidentally assigned
             # an org code with a different casing (e.g., Harvardx as opposed to HarvardX).
             # Case-insensitive matching allows us to deal with this kind of dirty data.
-            course_overviews = course_overviews.filter(org__iregex=r'(' + '|'.join(orgs) + ')')
+            org_filter = Q()  # Avoiding the `reduce()` for more readability, so a no-op filter starter is needed.
+            for org in orgs:
+                org_filter |= Q(org__iexact=org)
+            course_overviews = course_overviews.filter(org_filter)
 
         if filter_:
             course_overviews = course_overviews.filter(**filter_)


### PR DESCRIPTION
**Description:** 
currently organization filter on course overview is using regex which matches common organization slug and this will solves this problem.

**reference PR**: https://github.com/edx/edx-platform/pull/22631/files

**JIRA:** 
https://edlyio.atlassian.net/browse/EDE-1281

**Merge checklist:**

- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated

**Post merge:**
- [ ] Delete working branch (if not needed anymore)