### PR TITLE
add tournaments tab in courses

### DIFF
--- a/common/lib/xmodule/xmodule/tabs.py
+++ b/common/lib/xmodule/xmodule/tabs.py
@@ -9,6 +9,7 @@ from django.core.files.storage import get_storage_class
 from six import text_type
 from xblock.fields import List
 
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.lib.plugins import PluginError
 
 log = logging.getLogger("edx.courseware")
@@ -410,7 +411,7 @@ class CourseTabList(List):
 
         # If the feature is enabled, add tournaments tab in every course
         # by default.
-        if settings.FEATURES.get('ENABLE_TOURNAMENTS_TAB'):
+        if configuration_helpers.get_value("ENABLE_TOURNAMENTS_TAB", False):
             course.tabs.append(CourseTab.load('tournaments'))
 
     @staticmethod

--- a/common/lib/xmodule/xmodule/tabs.py
+++ b/common/lib/xmodule/xmodule/tabs.py
@@ -408,6 +408,11 @@ class CourseTabList(List):
         if settings.FEATURES.get('ENABLE_XVIEWER_TAB'):
             course.tabs.append(CourseTab.load('xviewer'))
 
+        # If the feature is enabled, add tournaments tab in every course
+        # by default.
+        if settings.FEATURES.get('ENABLE_TOURNAMENTS_TAB'):
+            course.tabs.append(CourseTab.load('tournaments'))
+
     @staticmethod
     def get_discussion(course):
         """

--- a/lms/templates/tournaments/index.html
+++ b/lms/templates/tournaments/index.html
@@ -1,7 +1,6 @@
 <%namespace name="static" file="../static_content.html"/>
 
-<div id="root" class="container">
-    <iframe src="https://sulctournamentscode.z19.web.core.windows.ne" title="Tournaments"
-    style="height:-webkit-fill-available;width:-webkit-fill-available;"
-    ></iframe>
-</div>
+<iframe src="https://sulctournamentscode.z19.web.core.windows.net/" title="Tournaments"
+style="height:500px;width:-webkit-fill-available;"
+></iframe>
+

--- a/lms/templates/tournaments/index.html
+++ b/lms/templates/tournaments/index.html
@@ -1,7 +1,7 @@
 <%namespace name="static" file="../static_content.html"/>
 
 <div id="root" class="container">
-    <iframe src="https://sulctwitchlivestreamcode.z19.web.core.windows.net/" title="Tournaments"
+    <iframe src="https://sulctournamentscode.z19.web.core.windows.ne" title="Tournaments"
     style="height:-webkit-fill-available;width:-webkit-fill-available;"
     ></iframe>
 </div>

--- a/lms/templates/tournaments/index.html
+++ b/lms/templates/tournaments/index.html
@@ -1,6 +1,0 @@
-<%namespace name="static" file="../static_content.html"/>
-
-<iframe src="https://sulctournamentscode.z19.web.core.windows.net/" title="Tournaments"
-style="height:500px;width:-webkit-fill-available;"
-></iframe>
-

--- a/lms/templates/tournaments/index.html
+++ b/lms/templates/tournaments/index.html
@@ -1,0 +1,7 @@
+<%namespace name="static" file="../static_content.html"/>
+
+<div id="root" class="container">
+    <iframe src="https://sulctwitchlivestreamcode.z19.web.core.windows.net/" title="Tournaments"
+    style="height:-webkit-fill-available;width:-webkit-fill-available;"
+    ></iframe>
+</div>

--- a/openedx/features/tournaments/plugins.py
+++ b/openedx/features/tournaments/plugins.py
@@ -3,6 +3,7 @@ from django.utils.translation import ugettext_noop
 
 from xmodule.tabs import TabFragmentViewMixin
 from courseware.tabs import EnrolledTab
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 
 
 class TournamentsTab(TabFragmentViewMixin, EnrolledTab):
@@ -20,7 +21,7 @@ class TournamentsTab(TabFragmentViewMixin, EnrolledTab):
         Returns true if this tab is enabled.
         """
         is_enabled = super(TournamentsTab, cls).is_enabled(course, user)
-        return settings.FEATURES.get('ENABLE_TOURNAMENTS_TAB', False) and is_enabled
+        return configuration_helpers.get_value("ENABLE_TOURNAMENTS_TAB", False) and is_enabled
 
     @property
     def uses_bootstrap(self):

--- a/openedx/features/tournaments/plugins.py
+++ b/openedx/features/tournaments/plugins.py
@@ -1,0 +1,30 @@
+from django.conf import settings
+from django.utils.translation import ugettext_noop
+
+from xmodule.tabs import TabFragmentViewMixin
+from courseware.tabs import EnrolledTab
+
+
+class TournamentsTab(TabFragmentViewMixin, EnrolledTab):
+    type = 'tournaments'
+    name = 'tournaments'
+    title = ugettext_noop('Tournaments')
+    is_movable = True
+    is_default = True
+    is_hideable = True
+    fragment_view_name = 'openedx.features.tournaments.views.TournamentsFragmentView'
+
+    @classmethod
+    def is_enabled(cls, course=None, user=None):
+        """
+        Returns true if this tab is enabled.
+        """
+        is_enabled = super(TournamentsTab, cls).is_enabled(course, user)
+        return settings.FEATURES.get('ENABLE_TOURNAMENTS_TAB', False) and is_enabled
+
+    @property
+    def uses_bootstrap(self):
+        """
+        Returns true if this tab is rendered with Bootstrap.
+        """
+        return True

--- a/openedx/features/tournaments/views.py
+++ b/openedx/features/tournaments/views.py
@@ -1,0 +1,27 @@
+from edxmako.shortcuts import render_to_string
+from web_fragments.fragment import Fragment
+
+from openedx.core.djangoapps.plugin_api.views import EdxFragmentView
+
+
+class TournamentsFragmentView(EdxFragmentView):
+    """
+    Component implementation of the Tournaments viewer.
+    """
+
+    def render_to_fragment(self, request, course_id=None, **kwargs):
+        """
+        Render the Tournament viewer to a fragment.
+
+        Args:
+            request: The Django request.
+            course_id: The id of the course in question.
+
+        Returns:
+            Fragment: The fragment representing the Tournament viewer
+        """
+        html = render_to_string('tournaments/index.html', {})
+
+        fragment = Fragment(html)
+        self.add_fragment_resource_urls(fragment)
+        return fragment

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,8 @@ setup(
             "teams = lms.djangoapps.teams.plugins:TeamsTab",
             "textbooks = lms.djangoapps.courseware.tabs:TextbookTabs",
             "wiki = lms.djangoapps.course_wiki.tab:WikiTab",
-            "xviewer = openedx.features.xviewer.plugins:XViewerTab"
+            "xviewer = openedx.features.xviewer.plugins:XViewerTab",
+            "tournaments = openedx.features.tournaments.plugins:TournamentsTab"
         ],
         "openedx.course_tool": [
             "course_bookmarks = openedx.features.course_bookmarks.plugins:CourseBookmarksTool",


### PR DESCRIPTION
**Description:** 
Integrate tournaments as a course tab.
Requires `ENABLE_TOURNAMENTS_TAB` to be added in site configurations. 
Related theme changes: https://github.com/REDHOUSEVE/edx-theme/pull/128

**JIRA:** 
https://edlyio.atlassian.net/browse/EDE-1321

**Testing instructions:**

1. Create a new course or use an existing one
2. Goto advanced settings
3. Change anything (and revert back if no change is required)
4. Save settings
5. Go to course in LMS
6. The "Tournaments" tab should be enabled. Can be hidden from Studio "pages" page.